### PR TITLE
Remove DataTable dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ packages/
 .vscode/
 .vs/
 *.exe
+/src/.idea
+/src/SimpleQuery.sln.DotSettings.user

--- a/src/SimpleQuery.Tests/App.config
+++ b/src/SimpleQuery.Tests/App.config
@@ -6,7 +6,7 @@
   </configSections>
   <connectionStrings>
     <add name="hana" connectionString="Server=192.168.1.200:30015;UID=SYSTEM;Password=Qt7k7dp=y;Current Schema=SYSTEM" />
-    <add name="sqlserver" connectionString="server=172.16.26.54\B2; database=master; user id=sa; password=sap@123" />
+    <add name="sqlserver" connectionString="server=localhost\B1; database=DBTeste; user id=sa; password=sap@123" />
     <add name="mysql" connectionString="User ID=root;Password=sap@123;Host=localhost;Port=3306;Database=sys;Protocol=TCP;Compress=false;Pooling=true;Min Pool Size=0;Max Pool Size=100;Connection Lifetime=0;" />
     <add name="postgres" connectionString="Server = localhost;Port=5432;Database=postgres;User Id=postgres;Password=sap@123; " />
     <add name="maxdb" connectionString="DATA SOURCE=localhost;INITIAL CATALOG=MAXDB;PASSWORD=sap@123;USER ID=DBADMIN;"/>

--- a/src/SimpleQuery.Tests/UnitTestDialectHana.cs
+++ b/src/SimpleQuery.Tests/UnitTestDialectHana.cs
@@ -171,13 +171,24 @@ namespace SimpleQuery.Tests
         [TestMethod]
         public void TestSelectOperationHana()
         {
+            IScriptBuilder builder = new ScriptHanaBuilder();
             var hanaConnection = System.Data.Common.DbProviderFactories.GetFactory("Sap.Data.Hana").CreateConnection();
             hanaConnection.ConnectionString = ConfigurationManager.ConnectionStrings["hana"].ConnectionString;
             hanaConnection.Open();
+
+            try
+            {
+                builder.Execute("drop table \"Cliente\"", hanaConnection);
+            }
+            catch (Exception)
+            {
+
+            }
+
             var trans = hanaConnection.BeginTransaction();
             using (var conn = hanaConnection)
             {
-                IScriptBuilder builder = new ScriptHanaBuilder();
+                
 
                 var cliente = new Cliente() { Id = 1, Nome = "Moisés", Ativo = true };
                 var cliente2 = new Cliente() { Id = 2, Nome = "José", Ativo = true };

--- a/src/SimpleQuery.Tests/UnitTestDialectHana.cs
+++ b/src/SimpleQuery.Tests/UnitTestDialectHana.cs
@@ -211,6 +211,49 @@ namespace SimpleQuery.Tests
         }
 
         [TestMethod]
+        public void TestSelectOperationHanaWithQuery()
+        {
+            IScriptBuilder builder = new ScriptHanaBuilder();
+            var hanaConnection = System.Data.Common.DbProviderFactories.GetFactory("Sap.Data.Hana").CreateConnection();
+            hanaConnection.ConnectionString = ConfigurationManager.ConnectionStrings["hana"].ConnectionString;
+            hanaConnection.Open();
+
+            try
+            {
+                builder.Execute("drop table \"Cliente\"", hanaConnection);
+            }
+            catch (Exception)
+            {
+
+            }
+
+            var trans = hanaConnection.BeginTransaction();
+            using (var conn = hanaConnection)
+            {
+
+
+                var cliente = new Cliente() { Id = 1, Nome = "Moisés", Ativo = true };
+                var cliente2 = new Cliente() { Id = 2, Nome = "José", Ativo = true };
+
+                var createTableScript = builder.GetCreateTableCommand<Cliente>();
+                var insertScript1 = builder.GetInsertCommand<Cliente>(cliente);
+                var insertScript2 = builder.GetInsertCommand<Cliente>(cliente2);
+                builder.Execute(createTableScript, conn);
+                builder.Execute(insertScript1, conn);
+                builder.Execute(insertScript2, conn);
+
+                var clientes = conn.Select<Cliente>("Select * From \"Cliente\" Order By \"Id\"");
+                Assert.AreEqual(2, clientes.Count());
+                Assert.AreEqual("Moisés", clientes.ToList()[0].Nome);
+                Assert.AreEqual("José", clientes.ToList()[1].Nome);
+
+                trans.Rollback();
+                builder.Execute("drop table \"Cliente\"", hanaConnection);
+            }
+        }
+
+
+            [TestMethod]
         public void TestHanaCreateTableScript()
         {
             IScriptBuilder builder = new ScriptHanaBuilder();

--- a/src/SimpleQuery.Tests/UnitTestDialectSQLServer.cs
+++ b/src/SimpleQuery.Tests/UnitTestDialectSQLServer.cs
@@ -284,6 +284,48 @@ namespace SimpleQuery.Tests
                 }
             }
         }
+        
+        
+
+        [TestMethod]
+        public void TestSelectOperationHanaWithQuery()
+        {
+            IScriptBuilder builder = new ScriptSqlServerBuilder();
+            var sqlConnection = new SqlConnection(connstring);
+            sqlConnection.Open();
+
+            try
+            {
+                builder.Execute("drop table \"Cliente\"", sqlConnection);
+            }
+            catch (Exception)
+            {
+
+            }
+            
+            using (var conn = sqlConnection)
+            {
+
+
+                var cliente = new Cliente() { Id = 1, Nome = "Moisés", Ativo = true };
+                var cliente2 = new Cliente() { Id = 2, Nome = "José", Ativo = true };
+
+                var createTableScript = builder.GetCreateTableCommand<Cliente>();
+                var insertScript1 = builder.GetInsertCommand<Cliente>(cliente);
+                var insertScript2 = builder.GetInsertCommand<Cliente>(cliente2);
+                builder.Execute(createTableScript, conn);
+                builder.Execute(insertScript1, conn);
+                builder.Execute(insertScript2, conn);
+
+                var clientes = conn.Select<Cliente>("Select * From \"Cliente\" Order By \"Id\"");
+                Assert.AreEqual(2, clientes.Count());
+                Assert.AreEqual("Moisés", clientes.ToList()[0].Nome);
+                Assert.AreEqual("José", clientes.ToList()[1].Nome);
+
+                builder.Execute("drop table \"Cliente\"", sqlConnection);
+            }
+        }
+        
         public string connstring => ConfigurationManager.ConnectionStrings["sqlserver"].ConnectionString;
 
 

--- a/src/SimpleQuery.Tests/UnitTestExtentionsSQLServer.cs
+++ b/src/SimpleQuery.Tests/UnitTestExtentionsSQLServer.cs
@@ -17,6 +17,15 @@ namespace SimpleQuery.Tests
             var conn = new SqlConnection(ConfigurationManager.ConnectionStrings["SQLServer"].ConnectionString);
             var scriptBuilder = conn.GetScriptBuild();
 
+            try
+            {
+                scriptBuilder.Execute("drop table \"Cliente\"", conn);
+            }
+            catch (Exception)
+            {
+
+            }
+            
             var cliente = new Cliente() { Nome = "Miranda" };
 
             var createTableScript = scriptBuilder.GetCreateTableCommand<Cliente>();

--- a/src/SimpleQuery/Data/Dialects/ScriptAnsiBuilder.cs
+++ b/src/SimpleQuery/Data/Dialects/ScriptAnsiBuilder.cs
@@ -82,6 +82,11 @@ namespace SimpleQuery.Data.Dialects
             return $"sequence_{entityName}_{columnName}".ToLower();
         }
 
+        public string GetCountCommand<T>(T obj, Expression<Func<T, bool>> expression = null) where T : class, new()
+        {
+            throw new NotImplementedException();
+        }
+
         public string GetDeleteCommand<T>(T obj, object key) where T : class, new()
         {
             var allProperties = obj.GetType().GetProperties();

--- a/src/SimpleQuery/Data/Dialects/ScriptCommon.cs
+++ b/src/SimpleQuery/Data/Dialects/ScriptCommon.cs
@@ -126,5 +126,12 @@ namespace SimpleQuery.Data.Dialects
             typeof(DateTime?)
         }.Contains(t);
         }
+        
+        protected string GetCountqueryComand<T>(T obj) where T : class, new()
+        {
+            var entityName = GetEntityName<T>();
+            
+            return $"select *  from \"{entityName}\" ";
+        }
     }
 }

--- a/src/SimpleQuery/Data/Dialects/ScriptHanaBuilder.cs
+++ b/src/SimpleQuery/Data/Dialects/ScriptHanaBuilder.cs
@@ -45,7 +45,7 @@ namespace SimpleQuery.Data.Dialects
             var wasClosed = dbConnection.State == ConnectionState.Closed;
             if (wasClosed) dbConnection.Open();
             var rowsCount = command.ExecuteNonQuery();
-            var dataTable = new DataTable();
+            
             Console.WriteLine($"{rowsCount} affected rows");
             if (wasClosed) dbConnection.Close();
         }
@@ -271,6 +271,18 @@ namespace SimpleQuery.Data.Dialects
             var select = GetSelectCommand<T>(obj);
             var where = GetWhereCommand<T>(expression);
             return select + " " + where;
+        }
+        
+        public string GetCountCommand<T>(T obj, Expression<Func<T, bool>> expression = null) where T : class, new()
+        {
+            var select = GetCountqueryComand<T>(obj);
+            
+            if (expression is null)
+            {
+                return select;
+            }
+            
+            return select + " " + GetWhereCommand<T>(expression);;
         }
 
         public Tuple<string, IEnumerable<DbSimpleParameter>> GetInsertCommandParameters<T>(T obj, bool includeKey = false) where T : class, new()

--- a/src/SimpleQuery/Data/Dialects/ScriptMySqlBuilder.cs
+++ b/src/SimpleQuery/Data/Dialects/ScriptMySqlBuilder.cs
@@ -26,7 +26,7 @@ namespace SimpleQuery.Data.Dialects
             var wasClosed = dbConnection.State == ConnectionState.Closed;
             if (wasClosed) dbConnection.Open();
             var rowsCount = command.ExecuteNonQuery();
-            var dataTable = new DataTable();
+            
             Console.WriteLine($"{rowsCount} affected rows");
             if (wasClosed) dbConnection.Close();
         }
@@ -114,6 +114,11 @@ namespace SimpleQuery.Data.Dialects
                 default:
                     return "nvarchar(255)";
             }
+        }
+
+        public string GetCountCommand<T>(T obj, Expression<Func<T, bool>> expression = null) where T : class, new()
+        {
+            throw new NotImplementedException();
         }
 
         public string GetDeleteCommand<T>(T obj, object key) where T : class, new()

--- a/src/SimpleQuery/Data/Dialects/ScriptPostGresBuilder.cs
+++ b/src/SimpleQuery/Data/Dialects/ScriptPostGresBuilder.cs
@@ -28,7 +28,7 @@ namespace SimpleQuery.Data.Dialects
             var wasClosed = dbConnection.State == ConnectionState.Closed;
             if (wasClosed) dbConnection.Open();
             var rowsCount = command.ExecuteNonQuery();
-            var dataTable = new DataTable();
+            
             Console.WriteLine($"{rowsCount} affected rows");
             if (wasClosed) dbConnection.Close();
         }
@@ -89,6 +89,11 @@ namespace SimpleQuery.Data.Dialects
         private string GetSequenceName(string entityName, string columnName)
         {
             return $"sequence_{entityName}_{columnName}".ToLower();
+        }
+
+        public string GetCountCommand<T>(T obj, Expression<Func<T, bool>> expression = null) where T : class, new()
+        {
+            throw new NotImplementedException();
         }
 
         public string GetDeleteCommand<T>(T obj, object key) where T : class, new()

--- a/src/SimpleQuery/Data/Dialects/ScriptSqlServerBuilder.cs
+++ b/src/SimpleQuery/Data/Dialects/ScriptSqlServerBuilder.cs
@@ -40,14 +40,19 @@ namespace SimpleQuery.Data.Dialects
         public void Execute(string commandText, IDbConnection dbConnection, IDbTransaction dbTransaction = null)
         {
             var command = dbConnection.CreateCommand();
+            
             if (dbTransaction != null)
                 command.Transaction = dbTransaction;
+            
             command.CommandText = commandText;
 
             var wasClosed = dbConnection.State == ConnectionState.Closed;
-            if (wasClosed) dbConnection.Open();
+            
+            if (wasClosed) 
+                dbConnection.Open();
+            
             var rowsCount = command.ExecuteNonQuery();
-            var dataTable = new DataTable();
+            
             Console.WriteLine($"{rowsCount} affected rows");
             if (wasClosed) dbConnection.Close();
         }
@@ -156,6 +161,18 @@ namespace SimpleQuery.Data.Dialects
 
             var sql = strBuilderSql.ToString();
             return sql;
+        }
+
+        public string GetCountCommand<T>(T obj, Expression<Func<T, bool>> expression = null) where T : class, new()
+        {
+            var select = GetCountqueryComand<T>(obj);
+            
+            if (expression is null)
+            {
+                return select;
+            }
+            
+            return select + " " + GetWhereCommand<T>(expression);;
         }
 
         public string GetUpdateCommand<T>(T obj) where T : class, new()

--- a/src/SimpleQuery/Data/Dialects/ScriptSqliteBuilder.cs
+++ b/src/SimpleQuery/Data/Dialects/ScriptSqliteBuilder.cs
@@ -108,6 +108,11 @@ namespace SimpleQuery.Data.Dialects
             }
         }
 
+        public string GetCountCommand<T>(T obj, Expression<Func<T, bool>> expression = null) where T : class, new()
+        {
+            throw new NotImplementedException();
+        }
+
         public string GetDeleteCommand<T>(T obj, object key) where T : class, new()
         {
             var allProperties = obj.GetType().GetProperties();

--- a/src/SimpleQuery/Domain/Data/Dialects/IScriptBuilder.cs
+++ b/src/SimpleQuery/Domain/Data/Dialects/IScriptBuilder.cs
@@ -40,6 +40,7 @@ namespace SimpleQuery.Domain.Data.Dialects
         /// <param name="obj">Instance model</param>
         /// <returns></returns>
         string GetSelectCommand<T>(T obj) where T : class, new();
+        
 
         /// <summary>
         /// Return table name based in Table Attribute or Class name
@@ -55,6 +56,14 @@ namespace SimpleQuery.Domain.Data.Dialects
         /// <param name="obj">Instance model</param>
         /// <returns></returns>
         string GetSelectCommand<T>(T obj, Expression<Func<T, bool>> expression) where T : class, new();
+        
+        /// <summary>
+        /// Return count from instance model
+        /// </summary>
+        /// <typeparam name="T">Class type</typeparam>
+        /// <param name="obj">Instance model</param>
+        /// <returns></returns>
+        string GetCountCommand<T>(T obj, Expression<Func<T, bool>> expression = null) where T : class, new();
 
         /// <summary>
         /// Return delete command from instance model

--- a/src/SimpleQuery/Extentions.cs
+++ b/src/SimpleQuery/Extentions.cs
@@ -4,18 +4,16 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
-using System.Dynamic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Transactions;
 
 namespace SimpleQuery
 {
     public static partial class Extentions
     {
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> GetQueries = new ConcurrentDictionary<RuntimeTypeHandle, string>();
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> GetQueries =
+            new ConcurrentDictionary<RuntimeTypeHandle, string>();
+
         /// <summary>
         /// Insert model and return last id
         /// </summary>
@@ -24,7 +22,8 @@ namespace SimpleQuery
         /// <param name="model">Instance model</param>
         /// <param name="dbTransaction">Transaction database</param>
         /// <returns></returns>
-        public static int InsertReturningId<T>(this IDbConnection dbConnection, T model, IDbTransaction dbTransaction = null)
+        public static int InsertReturningId<T>(this IDbConnection dbConnection, T model,
+            IDbTransaction dbTransaction = null)
             where T : class, new()
         {
             var wasClosed = dbConnection.State == ConnectionState.Closed;
@@ -48,6 +47,7 @@ namespace SimpleQuery
 
             return Convert.ToInt32(lastId);
         }
+
         /// <summary>
         /// Insert model in the database
         /// </summary>
@@ -56,8 +56,9 @@ namespace SimpleQuery
         /// <param name="model">Instance model</param>
         /// <param name="dbTransaction">Transaction database</param>
         /// <returns></returns>
-        public static T Insert<T>(this IDbConnection dbConnection, T model, bool includeKey = false, IDbTransaction dbTransaction = null)
-           where T : class, new()
+        public static T Insert<T>(this IDbConnection dbConnection, T model, bool includeKey = false,
+            IDbTransaction dbTransaction = null)
+            where T : class, new()
         {
             var wasClosed = dbConnection.State == ConnectionState.Closed;
 
@@ -80,10 +81,12 @@ namespace SimpleQuery
                 if (convertedValue != null)
                     keyProperty.SetValue(model, convertedValue);
             }
+
             return model;
         }
 
-        private static IDbCommand GetCommandInsert<T>(IDbConnection dbConnection, T model, IDbTransaction dbTransaction, IScriptBuilder scripBuilder, bool includeKey = false) where T : class, new()
+        private static IDbCommand GetCommandInsert<T>(IDbConnection dbConnection, T model, IDbTransaction dbTransaction,
+            IScriptBuilder scripBuilder, bool includeKey = false) where T : class, new()
         {
             var command = dbConnection.CreateCommand();
 
@@ -118,6 +121,7 @@ namespace SimpleQuery
                 return command;
             }
         }
+
         /// <summary>
         /// Update data model
         /// </summary>
@@ -126,7 +130,7 @@ namespace SimpleQuery
         /// <param name="model"></param>
         /// <param name="dbTransaction"></param>
         public static void Update<T>(this IDbConnection dbConnection, T model, IDbTransaction dbTransaction = null)
-           where T : class, new()
+            where T : class, new()
         {
             var wasClosed = dbConnection.State == ConnectionState.Closed;
 
@@ -142,10 +146,10 @@ namespace SimpleQuery
             Console.WriteLine($"{rowsCount} affected rows");
 
             if (wasClosed) dbConnection.Close();
-
         }
 
-        private static IDbCommand GetCommandUpdate<T>(IDbConnection dbConnection, T model, IDbTransaction dbTransaction, IScriptBuilder scripBuilder) where T : class, new()
+        private static IDbCommand GetCommandUpdate<T>(IDbConnection dbConnection, T model, IDbTransaction dbTransaction,
+            IScriptBuilder scripBuilder) where T : class, new()
         {
             var command = dbConnection.CreateCommand();
 
@@ -163,6 +167,7 @@ namespace SimpleQuery
 
                     command.Parameters.Add(param);
                 }
+
                 if (dbTransaction != null) command.Transaction = dbTransaction;
 
                 command.CommandText = updateCommand.Item1;
@@ -180,6 +185,7 @@ namespace SimpleQuery
                 return command;
             }
         }
+
         /// <summary>
         /// Delete model from database
         /// </summary>
@@ -188,7 +194,7 @@ namespace SimpleQuery
         /// <param name="model">Instance model</param>
         /// <param name="dbTransaction">Transaction database</param>
         public static void Delete<T>(this IDbConnection dbConnection, T model, IDbTransaction dbTransaction = null)
-          where T : class, new()
+            where T : class, new()
         {
             var wasClosed = dbConnection.State == ConnectionState.Closed;
 
@@ -210,7 +216,6 @@ namespace SimpleQuery
             Console.WriteLine($"{rowsCount} affected rows");
 
             if (wasClosed) dbConnection.Close();
-
         }
 
         /// <summary>
@@ -219,7 +224,8 @@ namespace SimpleQuery
         /// <param name="dbConnection">Connection</param>
         /// <param name="commandText">sql text command</param>
         /// <returns></returns>
-        public static int Execute(this IDbConnection dbConnection, string commandText, IDbTransaction transaction = null)
+        public static int Execute(this IDbConnection dbConnection, string commandText,
+            IDbTransaction transaction = null)
         {
             var wasClosed = dbConnection.State == ConnectionState.Closed;
 
@@ -227,7 +233,8 @@ namespace SimpleQuery
 
             IScriptBuilder scripBuilder = GetScriptBuild(dbConnection);
 
-            var command = dbConnection.CreateCommand(); if (transaction != null) command.Transaction = transaction;
+            var command = dbConnection.CreateCommand();
+            if (transaction != null) command.Transaction = transaction;
             command.CommandText = commandText;
             var rowsCount = command.ExecuteNonQuery();
 
@@ -235,52 +242,7 @@ namespace SimpleQuery
 
             return rowsCount;
         }
-
-        /// <summary>
-        /// Get all
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="dbConnection"></param>
-        /// <returns></returns>
-        public static IEnumerable<T> GetAll<T>(this IDbConnection dbConnection)
-           where T : class, new()
-        {
-            var wasClosed = dbConnection.State == ConnectionState.Closed;
-
-            if (wasClosed) dbConnection.Open();
-
-            var type = typeof(T);
-            var cacheType = typeof(List<T>);
-
-            IScriptBuilder scriptBuilder = GetScriptBuild(dbConnection);
-            var selectScript = scriptBuilder.GetSelectCommand<T>(new T());
-
-            var reader = scriptBuilder.ExecuteReader(selectScript, dbConnection);
-            var list = GetTypedList<T>(reader);
-            if (wasClosed) dbConnection.Close();
-
-            reader.Close();
-
-            return list;
-        }
-
-        static IEnumerable<T> GetTypedList<T>(IDataReader reader) where T : class, new()
-        {
-
-            var listModel = new List<T>();
-
-            var dataTable = new DataTable();
-            dataTable.Load(reader);
-
-            foreach (DataRow row in dataTable.Rows)
-            {
-                var newModel = GetModelByDataRow<T>(row);
-                listModel.Add(newModel);
-            }
-
-            return listModel;
-        }
-
+        
         /// <summary>
         /// Get all records from database in typed model
         /// </summary>
@@ -289,43 +251,109 @@ namespace SimpleQuery
         /// <param name="model">Instance model</param>
         /// <param name="dbTransaction">Transaction database</param>
         /// <returns></returns>
-        public static IEnumerable<T> GetAll<T>(this IDbConnection dbConnection, T model, IDbTransaction dbTransaction)
-          where T : class, new()
+        public static IEnumerable<T> GetAll<T>(this IDbConnection dbConnection, T model = null, IDbTransaction dbTransaction = null)
+            where T : class, new()
         {
             var wasClosed = dbConnection.State == ConnectionState.Closed;
 
-            if (wasClosed) dbConnection.Open();
+            if (wasClosed)
+                dbConnection.Open();
+            
+            var scripBuilder = GetScriptBuild(dbConnection);
+            var selectScript = scripBuilder.GetSelectCommand<T>(new T());
+            
+            var elements = QueryOptionmized(dbConnection, selectScript, GetModel<T>);
+            
+            if (wasClosed)
+                dbConnection.Close();
 
-            var type = typeof(T);
-            var cacheType = typeof(List<T>);
-
-            IScriptBuilder scripBuilder = GetScriptBuild(dbConnection);
-            var selectScript = scripBuilder.GetSelectCommand<T>(model);
-
-            var reader = scripBuilder.ExecuteReader(selectScript, dbConnection);
-            var listModel = new List<T>();
-
-            var dataTable = new DataTable();
-            dataTable.Load(reader);
-
-            foreach (DataRow row in dataTable.Rows)
-            {
-                var newModel = GetModelByDataRow<T>(row);
-                listModel.Add(newModel);
-            }
-
-            if (wasClosed) dbConnection.Close();
-
-            reader.Close();
-
-            return listModel;
+            return elements;
         }
 
+         static TModel[] QueryOptionmized<TModel>(
+            IDbConnection connection,
+            string command,
+            Func<IDataReader, Dictionary<string, int>, TModel> toObject) where TModel : class, new()
+        {
+            var quantidadeDeRegistros = QueryCount(connection, command);
+            
+            var elementos = new TModel[quantidadeDeRegistros];
+            var scripBuilder = GetScriptBuild(connection);
+
+            using (var rdr = scripBuilder.ExecuteReader(command, connection))
+            {
+                var cachedOrdinal = new Dictionary<string, int>(rdr.FieldCount);
+
+                for (var i = 0; i < rdr.FieldCount; i++)
+                {
+                    try
+                    {
+                        var name = rdr.GetName(i);
+                        cachedOrdinal.Add(rdr.GetName(i), rdr.GetOrdinal(name));
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                        throw;
+                    }
+                }
+
+                var elemnto = 0;
+
+                while (rdr.Read())
+                {
+                    var novoRegistro = toObject(rdr, cachedOrdinal);
+
+                    elementos[elemnto] = novoRegistro;
+                    elemnto++;
+                }
+
+                rdr.Close();
+            }
+
+            return elementos;
+        }
+
+         private static int QueryCount(IDbConnection dbConnection, string command)
+         {
+             var commandCount = "SELECT COUNT(1) FROM ({command}) as a";
+
+             var qtd = dbConnection.Scalar<int>(command);
+
+             return qtd.FirstOrDefault();
+         }
+
+         private static T GetModel<T>(IDataReader dataReader, Dictionary<string, int> record) where T : class, new()
+         {
+             var model = new T();
+
+             var properties = model
+                 .GetType()
+                 .GetProperties(BindingFlags.Instance | BindingFlags.Public);
+
+             foreach (var item in properties)
+             {
+                 if (!record.TryGetValue(item.Name, out var fieldIndex))
+                 {
+                     continue;
+                 }
+                 
+                 var rowValue = dataReader[fieldIndex];
+                 var value = ChangeType(rowValue, item.PropertyType);
+
+                 item.SetValue(model,  dataReader.IsDBNull(fieldIndex) ? null : value);
+             }
+
+             return model;
+         }
+         
         private static T GetModelByDataRow<T>(DataRow row) where T : class, new()
         {
             var model = new T();
 
-            var properties = model.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
+            var properties = model
+                .GetType()
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public);
 
             foreach (var item in properties)
             {
@@ -339,8 +367,8 @@ namespace SimpleQuery
             }
 
             return model;
-
         }
+
         /// <summary>
         /// Convert a type object to another
         /// </summary>
@@ -360,6 +388,7 @@ namespace SimpleQuery
 
                 t = Nullable.GetUnderlyingType(t);
             }
+
             if (value is DBNull)
             {
                 if (conversion.AssemblyQualifiedName.Contains("System.DateTime") ||
@@ -374,6 +403,7 @@ namespace SimpleQuery
                 else
                     throw new Exception("Type value is not mapped");
             }
+
             return Convert.ChangeType(value, t);
         }
 
@@ -399,4 +429,5 @@ namespace SimpleQuery
                 return new ScriptAnsiBuilder();
         }
     }
+    
 }

--- a/src/SimpleQuery/Extentions.cs
+++ b/src/SimpleQuery/Extentions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace SimpleQuery
 {
@@ -318,11 +319,34 @@ namespace SimpleQuery
 
         private static int QueryCount(IDbConnection dbConnection, string command)
         {
-            var commandCount = $"SELECT COUNT(1) FROM ({command}) as a";
+            var semOrderBy = SubStringInicioAte(command, "ORDER BY");
+            var commandCount = $"SELECT COUNT(1) FROM ({semOrderBy}) as a";
 
             var qtd = dbConnection.Scalar<int>(commandCount);
 
             return qtd.FirstOrDefault();
+        }
+        
+        public static string SubStringInicioAte(this string valor, string textoDoIndice)
+        {
+            var indiceFinal = valor?.IndexOf(textoDoIndice, StringComparison.InvariantCultureIgnoreCase) ?? -1;
+
+            return indiceFinal == -1 ? valor : SubStringInicioAte(valor, indiceFinal);
+        }
+
+        public static string SubStringInicioAte(this string valor, int indiceFinal)
+        {
+            if (string.IsNullOrWhiteSpace(valor))
+                return string.Empty;
+
+            if (indiceFinal == -1)
+            {
+                return valor;
+            }
+
+            return valor
+                .Substring(0, indiceFinal)
+                .Trim();
         }
 
         private static T GetModel<T>(IDataReader dataReader, Dictionary<string, int> record) where T : class, new()


### PR DESCRIPTION
When we use HANA de DataTable execute this query in the server. We (Invent) open a bug at SAP but here remove this dependence.

Sample Código : 
![image](https://user-images.githubusercontent.com/447851/187785188-2b2f43f7-6284-42f8-9e61-01c8e47d968b.png)

Query  Executada Automáticamente : 
SELECT
  T1.SCHEMA_NAME
  ,T1.TABLE_NAME
  ,T1.COLUMN_NAME
  ,T1.POSITION
  ,T1.IS_NULLABLE
  ,CASE WHEN COUNT(*) OVER (PARTITION BY T2.SCHEMA_NAME, T2.TABLE_NAME, T2.COLUMN_NAME, T2.INDEX_NAME)=1 AND T2.CONSTRAINT LIKE '%UNIQUE%' THEN 'TRUE' ELSE NULL END IS_UNIQUE
  ,CASE WHEN T2.CONSTRAINT = 'PRIMARY KEY' THEN 'TRUE' ELSE NULL END IS_PRIMARY_KEY
  ,CASE WHEN T2.CONSTRAINT LIKE '%UNIQUE%' THEN T2.INDEX_NAME ELSE NULL END INDEX_NAME
  ,CASE WHEN T2.CONSTRAINT LIKE '%UNIQUE%' THEN T2.IS_UNIQUE_ALTPK ELSE NULL END IS_UNIQUE_ALTPK
FROM
  SYS.TABLE_COLUMNS T1
  LEFT OUTER JOIN (SELECT
                     SCHEMA_NAME
                     ,TABLE_NAME
                     ,INDEX_NAME
                     ,COLUMN_NAME
                     ,CONSTRAINT
                     ,'TRUE' AS IS_UNIQUE_ALTPK
                   FROM
                     SYS.INDEX_COLUMNS
                   WHERE
                     CONSTRAINT IN ('NOT NULL UNIQUE','UNIQUE','PRIMARY KEY')) T2
                   ON (T1.SCHEMA_NAME = T2.SCHEMA_NAME) AND (T1.TABLE_NAME = T2.TABLE_NAME) AND (T1.COLUMN_NAME = T2.COLUMN_NAME)
WHERE
  (NOT (T1.SCHEMA_NAME IN ('SYS'))
   AND NOT (T1.SCHEMA_NAME LIKE '_SYS_%')
   AND (T1.TABLE_NAME = ?)
  )
ORDER BY
  T1.SCHEMA_NAME

  ,T1.TABLE_NAME 



